### PR TITLE
Allow inheritance in enhanced beans

### DIFF
--- a/src/com/avaje/ebean/bean/EntityBean.java
+++ b/src/com/avaje/ebean/bean/EntityBean.java
@@ -1,0 +1,4 @@
+package com.avaje.ebean.bean;
+
+public interface EntityBean {
+}


### PR DESCRIPTION
I couldn't figure out how to access the compiler's classloader so
this was the second best solution.

Problem 1 is when there is an inheritance in the beans. E.g. A extends B.
When A is loaded, the classloader will not know anything about B and thus throw
ClassNotFoundException. This fixes that by trying all classes compiled as well.

Problem 2 is that already enhanced classes, once loaded, requires access to the
class structure (we only use EntityBean, but I'm sure there are others for more
complex structures). This was fixed by just keeping an empty interface in the
plugin.
