### PR TITLE
Workaround because inner classes are not handled properly

### DIFF
--- a/src/org/avaje/idea/ebean10/plugin/EbeanEnhancementTask.java
+++ b/src/org/avaje/idea/ebean10/plugin/EbeanEnhancementTask.java
@@ -142,8 +142,12 @@ class EbeanEnhancementTask {
 
       progressIndicator.setText2(className);
 
+      classBytesReader.setSearchScopeFromFile(file);
+
       ApplicationManager.getApplication().runWriteAction(() ->
           processEnhancement(classLoader, combinedTransform, className, file));
+
+      classBytesReader.setSearchScopeFromFile(null);
     }
 
     logInfo("Ebean enhancement done!");

--- a/src/org/avaje/idea/ebean10/plugin/IdeaClassBytesReader.java
+++ b/src/org/avaje/idea/ebean10/plugin/IdeaClassBytesReader.java
@@ -157,7 +157,10 @@ public class IdeaClassBytesReader implements ClassBytesReader {
         searchScope = findModule(virtualFile);
         if (searchScope == null) {
           String className = virtualFile.getName().replaceAll("$.*", "");
-          searchScope = findModule(virtualFile.getParent().findChild(className + ".class"));
+          final VirtualFile parentChild = virtualFile.getParent().findChild(className + ".class");
+          if (parentChild != null) {
+            searchScope = findModule(parentChild);
+          }
         }
       }
       if (searchScope == null) {

--- a/src/org/avaje/idea/ebean10/plugin/IdeaClassBytesReader.java
+++ b/src/org/avaje/idea/ebean10/plugin/IdeaClassBytesReader.java
@@ -30,6 +30,7 @@ import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.GlobalSearchScope;
 
 import java.io.File;
@@ -102,9 +103,10 @@ public class IdeaClassBytesReader implements ClassBytesReader {
         return null;
       }
 
-      final VirtualFile containingFile = psiClass.getContainingFile().getVirtualFile();
-      if (containingFile == null) {
-        warn("Couldn't find containing file for PsiClass: " + psiClass);
+      final PsiFile psiClassContainingFile = psiClass.getContainingFile();
+      final VirtualFile containingFile = psiClassContainingFile.getVirtualFile();
+      if (containingFile == null || !"class".equals(psiClassContainingFile.getFileType().getDefaultExtension())) {
+        warn("Couldn't find containing class for PsiClass: " + psiClass);
         return null;
       }
 

--- a/src/org/avaje/idea/ebean10/plugin/IdeaClassBytesReader.java
+++ b/src/org/avaje/idea/ebean10/plugin/IdeaClassBytesReader.java
@@ -24,6 +24,9 @@ import com.intellij.openapi.compiler.CompileContext;
 import com.intellij.openapi.compiler.CompilerMessageCategory;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.IndexNotReadyException;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
@@ -33,6 +36,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
+
+import org.jetbrains.annotations.NotNull;
+import net.jcip.annotations.NotThreadSafe;
+
+import static java.util.Collections.singleton;
 
 /**
  * Lookup a class file by given class name.
@@ -40,14 +49,21 @@ import java.util.Map;
  * @author Mario Ivankovits, mario@ops.co.at
  * @author yevgenyk - Updated 28/04/2014 for IDEA 13
  */
+@NotThreadSafe
 public class IdeaClassBytesReader implements ClassBytesReader {
 
   private final CompileContext compileContext;
   private final Map<String, File> compiledClasses;
+  private final JavaPsiFacade psiFacade;
+  private final GlobalSearchScope globalSearchScope;
+  private GlobalSearchScope searchScope;
 
   public IdeaClassBytesReader(CompileContext compileContext, Map<String, File> compiledClasses) {
     this.compileContext = compileContext;
     this.compiledClasses = compiledClasses;
+    globalSearchScope = GlobalSearchScope.allScope(compileContext.getProject());
+    this.searchScope = GlobalSearchScope.allScope(compileContext.getProject());
+    this.psiFacade = JavaPsiFacade.getInstance(compileContext.getProject());
   }
 
   @Override
@@ -75,11 +91,9 @@ public class IdeaClassBytesReader implements ClassBytesReader {
 
   private byte[] lookupClassBytesFallback(String classNamePath) {
     // Create a Psi compatible className
-    final String className = classNamePath.replace('/', '.').replace('$', '.');
+    final String className = convertToClassNamePath(classNamePath);
     try {
 
-      final JavaPsiFacade psiFacade = JavaPsiFacade.getInstance(compileContext.getProject());
-      final GlobalSearchScope searchScope = GlobalSearchScope.allScope(compileContext.getProject());
       final PsiClass psiClass = psiFacade.findClass(className, searchScope);
       if (psiClass == null) {
         warn("Couldn't find PsiClass for class: " + className);
@@ -92,7 +106,7 @@ public class IdeaClassBytesReader implements ClassBytesReader {
         return null;
       }
 
-      final VirtualFile classFile = getClassFile(containingFile, classNamePath);
+      final VirtualFile classFile = getClassFileRelativeContainingFile(containingFile, classNamePath, psiClass, className);
       if (classFile == null) {
         warn("Couldn't find .class file for class: " + className);
         return null;
@@ -111,59 +125,50 @@ public class IdeaClassBytesReader implements ClassBytesReader {
     }
   }
 
-  private VirtualFile getClassFile(VirtualFile containingFile, String classNamePath) {
-    final Module module = compileContext.getModuleByFile(containingFile);
-    if (module == null) {
-      // File is not linked to a project module - probably from a 3rd party .jar
+  private VirtualFile getClassFileRelativeContainingFile(VirtualFile containingFile, String classNamePath, PsiClass psiClass, String className) {
+    ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(psiClass.getProject());
+    VirtualFile classRootForFile = projectFileIndex.getClassRootForFile(containingFile);
+    if (classRootForFile == null) {
+      warn("Couldn't find class root '" + className + "' in project file index.");
       return containingFile;
     }
-
-    final VirtualFile classFile = getClassFileFromModule(module, classNamePath);
-    if (classFile == null) {
-      warn(module.getName() + ": Couldn't find compiled file for class: " + classNamePath);
+    VirtualFile fileByRelativePath = classRootForFile.findFileByRelativePath(classNamePath + ".class");
+    if (fileByRelativePath == null) {
+      warn("Couldn't find file for class '" + className + "' in project file index.");
       return containingFile;
     }
-    return classFile;
-  }
-
-  private VirtualFile getClassFileFromModule(Module module, String classNamePath) {
-    final String classNamePathWithExtension = classNamePath + ".class";
-
-    // Search the file in the module's main output directory.
-    final VirtualFile requiredFile = getClassFileFromModuleMainOutput(module, classNamePathWithExtension);
-    if (requiredFile != null) {
-      return requiredFile;
-    }
-
-    // File is not in the module's main output directory.
-    // Search the file in the module's test output directory.
-    return getClassFileFromModuleTestOutput(module, classNamePathWithExtension);
-  }
-
-  private VirtualFile getClassFileFromModuleMainOutput(Module module, String classNamePathWithExtension) {
-    // Search the file in the module's main output directory.
-    final VirtualFile outputDirectory = compileContext.getModuleOutputDirectory(module);
-    if (outputDirectory == null) {
-      warn(module.getName() + ": Couldn't find main output directory!");
-      return null;
-    }
-
-    return outputDirectory.findFileByRelativePath(classNamePathWithExtension);
-  }
-
-  private VirtualFile getClassFileFromModuleTestOutput(Module module, String classNamePathWithExtension) {
-    // Search the file in the module's test output directory.
-    final VirtualFile outputDirectory = compileContext.getModuleOutputDirectoryForTests(module);
-    if (outputDirectory == null) {
-      warn(module.getName() + ": Couldn't find test output directory!");
-      return null;
-    }
-
-    return outputDirectory.findFileByRelativePath(classNamePathWithExtension);
+    return fileByRelativePath;
   }
 
   private void warn(String message) {
     // warning level messages not showing in Messages so using INFORMATION here
     compileContext.addMessage(CompilerMessageCategory.INFORMATION, "WARN: " + message, null, -1, -1);
+  }
+
+  void setSearchScopeFromFile(final File file) {
+    if (file != null) {
+      VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByIoFile(file);
+      if (virtualFile != null) {
+        for (Module module : compileContext.getCompileScope().getAffectedModules()) {
+          Set<VirtualFile> mainRoot = singleton(compileContext.getModuleOutputDirectory(module));
+          if (VfsUtil.isUnder(virtualFile, mainRoot)) {
+            this.searchScope = module.getModuleWithDependenciesAndLibrariesScope(false);
+            return;
+          }
+          Set<VirtualFile> testRoot = singleton(compileContext.getModuleOutputDirectoryForTests(module));
+          if (VfsUtil.isUnder(virtualFile, testRoot)) {
+            this.searchScope = module.getModuleWithDependenciesAndLibrariesScope(true);
+            return;
+          }
+        }
+      }
+      warn("Couldn't find the Module for file " + file);
+    }
+    this.searchScope = globalSearchScope;
+  }
+
+  @NotNull
+  private String convertToClassNamePath(final String className) {
+    return className.replace('/', '.').replace('$', '.');
   }
 }


### PR DESCRIPTION
IntelliJ 2016.3.1 (IU-163.9166.29) does not handle inner classes
in the way that the IdeaClassBytesReader expected, throwing Exception.

This may be a bug in IntelliJ or it may be expected behaviour, but this
works around the issue.

An example that illustrates the problem is available here:
https://github.com/tobias-/ebean-idea-enhancer/tree/inner_class_problem