### PR TITLE
Fix file url's resolving to a host

### DIFF
--- a/src/org/avaje/idea/ebean10/plugin/EbeanEnhancementTask.java
+++ b/src/org/avaje/idea/ebean10/plugin/EbeanEnhancementTask.java
@@ -19,8 +19,6 @@
 
 package org.avaje.idea.ebean10.plugin;
 
-import io.ebean.enhance.agent.InputStreamTransform;
-import io.ebean.enhance.agent.Transformer;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.compiler.CompileContext;
 import com.intellij.openapi.compiler.CompilerMessageCategory;
@@ -29,7 +27,8 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ActionRunner;
-import com.intellij.util.containers.HashSet;
+import io.ebean.enhance.agent.InputStreamTransform;
+import io.ebean.enhance.agent.Transformer;
 import io.ebean.typequery.agent.CombinedTransform;
 import io.ebean.typequery.agent.QueryBeanTransformer;
 
@@ -40,9 +39,8 @@ import java.lang.instrument.IllegalClassFormatException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import static io.ebean.enhance.agent.InputStreamTransform.readBytes;
 
@@ -172,7 +170,7 @@ class EbeanEnhancementTask {
 
     Module[] modules = compileContext.getProjectCompileScope().getAffectedModules();
 
-    Set<URL> out = new HashSet<>();
+    List<URL> out = new ArrayList<>();
     for (Module module : modules) {
       addFileSystemUrl(out, compileContext.getModuleOutputDirectory(module));
       addFileSystemUrl(out, compileContext.getModuleOutputDirectoryForTests(module));
@@ -191,9 +189,13 @@ class EbeanEnhancementTask {
     compileContext.addMessage(CompilerMessageCategory.ERROR, msg, null, -1, -1);
   }
 
-  private void addFileSystemUrl(Set<URL> out, VirtualFile outDir) throws MalformedURLException {
+  private void addFileSystemUrl(List<URL> out, VirtualFile outDir) throws MalformedURLException {
     if (outDir != null) {
-      out.add(new URL(outDir.getUrl()));
+      String url = outDir.getUrl();
+
+      url = url.replace("file://", "file:/");
+
+      out.add(new URL(url));
     }
   }
 


### PR DESCRIPTION
Hi,

This pull request fixes 2 problems:

- Fix file url's resolving to a host
- Fix url host lookup in HashSet

In the EbeanEnhancementTask the classpaths are picked up from the compileContext and passed to the classloader in a URL object. The url will then be something like this (in windows):

`file://C/Development/project/directory`

The // after the file: will cause the URLClassLoader to try to resolve C as a host i.o. a drive. In this pull request I did a replace to test this, but there must be a better way to fix this.

The other problem is that the urls where stored in a HashSet, and the hashcode method in the URL class might triggers a host lookup. Putting them in a list will avoid this unnecessary lookup.