### PR TITLE
Use module searchscope for finding classes

### DIFF
--- a/src/main/java/io/ebean/idea/ebean10/plugin/CompiledFileCollector.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/CompiledFileCollector.java
@@ -21,8 +21,6 @@ package io.ebean.idea.ebean10.plugin;
 
 import com.intellij.openapi.compiler.CompilationStatusListener;
 import com.intellij.openapi.compiler.CompileContext;
-import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiDocumentManager;
 
 import java.io.File;
 import java.util.Collection;

--- a/src/main/java/io/ebean/idea/ebean10/plugin/EbeanEnhancementTask.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/EbeanEnhancementTask.java
@@ -160,7 +160,12 @@ class EbeanEnhancementTask {
       File file = entry.getValue();
 
       progressIndicator.setText2(className);
+
+      classBytesReader.setSearchScopeFromFile(file);
+
       processEnhancement(classLoader, transformer, className, file);
+
+      classBytesReader.setSearchScopeFromFile(null);
     }
 
     logInfo("Ebean enhancement done!");

--- a/src/main/java/io/ebean/idea/ebean10/plugin/EbeanEnhancementTask.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/EbeanEnhancementTask.java
@@ -79,7 +79,7 @@ class EbeanEnhancementTask {
     TransactionGuard.getInstance()
         .submitTransactionLater(project,
             () -> ApplicationManager.getApplication().runWriteAction(
-                () -> performEnhancement()));
+              this::performEnhancement));
   }
 
   /**
@@ -149,7 +149,7 @@ class EbeanEnhancementTask {
 
     Transformer transformer = new Transformer(classBytesReader, "debug=" + debugLevel, manifest);
 
-    transformer.setLogout(msg -> logInfo(msg));
+    transformer.setLogout(this::logInfo);
 
     ProgressIndicator progressIndicator = compileContext.getProgressIndicator();
     progressIndicator.setIndeterminate(true);

--- a/src/main/java/io/ebean/idea/ebean10/plugin/EbeanEnhancementTask.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/EbeanEnhancementTask.java
@@ -217,6 +217,9 @@ class EbeanEnhancementTask {
   private void addFileSystemUrl(List<URL> out, VirtualFile outDir) throws MalformedURLException {
     if (outDir != null) {
       String url = outDir.getUrl();
+      if (outDir.isDirectory() && !url.endsWith("/")) {
+        url = url + "/";
+      }
       // take into account windows file system
       url = url.replace("file://", "file:/");
       out.add(new URL(url));

--- a/src/main/java/io/ebean/idea/ebean10/plugin/EbeanEnhancementTask.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/EbeanEnhancementTask.java
@@ -220,8 +220,10 @@ class EbeanEnhancementTask {
       if (outDir.isDirectory() && !url.endsWith("/")) {
         url = url + "/";
       }
-      // take into account windows file system
-      url = url.replace("file://", "file:/");
+      if ('\\' == File.separatorChar) {
+        // take into account windows file system
+        url = url.replace("file://", "file:/");
+      }
       out.add(new URL(url));
     }
   }

--- a/src/main/java/io/ebean/idea/ebean10/plugin/IOUtils.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/IOUtils.java
@@ -1,9 +1,15 @@
 package io.ebean.idea.ebean10.plugin;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 
 /**
  * Utilities for IO.
@@ -47,6 +53,31 @@ class IOUtils {
       }
     } finally {
       out.close();
+    }
+  }
+
+  static URL byteArrayToURL(final byte[] bytes) {
+    try {
+      return new URL(null, "foobar://foo/bar", new URLStreamHandler() {
+        @Override
+        protected URLConnection openConnection(final URL u) throws IOException {
+          final ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+
+          return new URLConnection(null) {
+
+            @Override
+            public void connect() throws IOException {
+            }
+
+            @Override
+            public InputStream getInputStream() throws IOException {
+              return bais;
+            }
+          };
+        }
+      });
+    } catch (MalformedURLException e) {
+      throw new UncheckedIOException(e);
     }
   }
 }

--- a/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
@@ -93,7 +93,7 @@ public class IdeaClassBytesReader implements ClassBytesReader {
 
   private byte[] lookupClassBytesFallback(String classNamePath) {
     // Create a Psi compatible className
-    final String className = convertToClassNamePath(classNamePath);
+    final String className = convertToClassName(classNamePath);
     try {
 
       final PsiClass psiClass = psiFacade.findClass(className, searchScope);
@@ -184,7 +184,7 @@ public class IdeaClassBytesReader implements ClassBytesReader {
   }
 
   @NotNull
-  private String convertToClassNamePath(final String className) {
+  private String convertToClassName(final String className) {
     return className.replace('/', '.').replace('$', '.');
   }
 }

--- a/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.GlobalSearchScope;
 import io.ebean.enhance.common.ClassBytesReader;
 
@@ -102,9 +103,10 @@ public class IdeaClassBytesReader implements ClassBytesReader {
         return null;
       }
 
-      final VirtualFile containingFile = psiClass.getContainingFile().getVirtualFile();
-      if (containingFile == null) {
-        warn("Couldn't find containing file for PsiClass: " + psiClass);
+      final PsiFile psiClassContainingFile = psiClass.getContainingFile();
+      final VirtualFile containingFile = psiClassContainingFile.getVirtualFile();
+      if (containingFile == null || !"class".equals(psiClassContainingFile.getFileType().getDefaultExtension())) {
+        warn("Couldn't find containing class for PsiClass: " + psiClass);
         return null;
       }
 

--- a/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
@@ -157,7 +157,10 @@ public class IdeaClassBytesReader implements ClassBytesReader {
         searchScope = findModule(virtualFile);
         if (searchScope == null) {
           String className = virtualFile.getName().replaceAll("$.*", "");
-          searchScope = findModule(virtualFile.getParent().findChild(className + ".class"));
+          final VirtualFile parentChild = virtualFile.getParent().findChild(className + ".class");
+          if (parentChild != null) {
+            searchScope = findModule(parentChild);
+          }
         }
       }
       if (searchScope == null) {

--- a/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
@@ -23,6 +23,9 @@ import com.intellij.openapi.compiler.CompileContext;
 import com.intellij.openapi.compiler.CompilerMessageCategory;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.IndexNotReadyException;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
@@ -33,6 +36,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.jetbrains.annotations.NotNull;
+import net.jcip.annotations.NotThreadSafe;
+
+import static java.util.Collections.singleton;
+import static java.util.Optional.ofNullable;
 
 /**
  * Lookup a class file by given class name.
@@ -40,14 +51,21 @@ import java.util.Map;
  * @author Mario Ivankovits, mario@ops.co.at
  * @author yevgenyk - Updated 28/04/2014 for IDEA 13
  */
+@NotThreadSafe
 public class IdeaClassBytesReader implements ClassBytesReader {
 
   private final CompileContext compileContext;
   private final Map<String, File> compiledClasses;
+  private final JavaPsiFacade psiFacade;
+  private final GlobalSearchScope globalSearchScope;
+  private GlobalSearchScope searchScope;
 
   public IdeaClassBytesReader(CompileContext compileContext, Map<String, File> compiledClasses) {
     this.compileContext = compileContext;
     this.compiledClasses = compiledClasses;
+    globalSearchScope = GlobalSearchScope.allScope(compileContext.getProject());
+    this.searchScope = GlobalSearchScope.allScope(compileContext.getProject());
+    this.psiFacade = JavaPsiFacade.getInstance(compileContext.getProject());
   }
 
   @Override
@@ -75,11 +93,9 @@ public class IdeaClassBytesReader implements ClassBytesReader {
 
   private byte[] lookupClassBytesFallback(String classNamePath) {
     // Create a Psi compatible className
-    final String className = classNamePath.replace('/', '.').replace('$', '.');
+    final String className = convertToClassNamePath(classNamePath);
     try {
 
-      final JavaPsiFacade psiFacade = JavaPsiFacade.getInstance(compileContext.getProject());
-      final GlobalSearchScope searchScope = GlobalSearchScope.allScope(compileContext.getProject());
       final PsiClass psiClass = psiFacade.findClass(className, searchScope);
       if (psiClass == null) {
         warn("Couldn't find PsiClass for class: " + className);
@@ -92,7 +108,7 @@ public class IdeaClassBytesReader implements ClassBytesReader {
         return null;
       }
 
-      final VirtualFile classFile = getClassFile(containingFile, classNamePath);
+      final VirtualFile classFile = getClassFileRelativeContainingFile(containingFile, classNamePath, psiClass, className);
       if (classFile == null) {
         warn("Couldn't find .class file for class: " + className);
         return null;
@@ -111,59 +127,60 @@ public class IdeaClassBytesReader implements ClassBytesReader {
     }
   }
 
-  private VirtualFile getClassFile(VirtualFile containingFile, String classNamePath) {
-    final Module module = compileContext.getModuleByFile(containingFile);
-    if (module == null) {
-      // File is not linked to a project module - probably from a 3rd party .jar
+  private VirtualFile getClassFileRelativeContainingFile(VirtualFile containingFile, String classNamePath, PsiClass psiClass, String className) {
+    ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(psiClass.getProject());
+    VirtualFile classRootForFile = projectFileIndex.getClassRootForFile(containingFile);
+    if (classRootForFile == null) {
+      warn("Couldn't find class root '" + className + "' in project file index.");
       return containingFile;
     }
-
-    final VirtualFile classFile = getClassFileFromModule(module, classNamePath);
-    if (classFile == null) {
-      warn(module.getName() + ": Couldn't find compiled file for class: " + classNamePath);
+    VirtualFile fileByRelativePath = classRootForFile.findFileByRelativePath(classNamePath + ".class");
+    if (fileByRelativePath == null) {
+      warn("Couldn't find file for class '" + className + "' in project file index.");
       return containingFile;
     }
-    return classFile;
-  }
-
-  private VirtualFile getClassFileFromModule(Module module, String classNamePath) {
-    final String classNamePathWithExtension = classNamePath + ".class";
-
-    // Search the file in the module's main output directory.
-    final VirtualFile requiredFile = getClassFileFromModuleMainOutput(module, classNamePathWithExtension);
-    if (requiredFile != null) {
-      return requiredFile;
-    }
-
-    // File is not in the module's main output directory.
-    // Search the file in the module's test output directory.
-    return getClassFileFromModuleTestOutput(module, classNamePathWithExtension);
-  }
-
-  private VirtualFile getClassFileFromModuleMainOutput(Module module, String classNamePathWithExtension) {
-    // Search the file in the module's main output directory.
-    final VirtualFile outputDirectory = compileContext.getModuleOutputDirectory(module);
-    if (outputDirectory == null) {
-      warn(module.getName() + ": Couldn't find main output directory!");
-      return null;
-    }
-
-    return outputDirectory.findFileByRelativePath(classNamePathWithExtension);
-  }
-
-  private VirtualFile getClassFileFromModuleTestOutput(Module module, String classNamePathWithExtension) {
-    // Search the file in the module's test output directory.
-    final VirtualFile outputDirectory = compileContext.getModuleOutputDirectoryForTests(module);
-    if (outputDirectory == null) {
-      warn(module.getName() + ": Couldn't find test output directory!");
-      return null;
-    }
-
-    return outputDirectory.findFileByRelativePath(classNamePathWithExtension);
+    return fileByRelativePath;
   }
 
   private void warn(String message) {
     // warning level messages not showing in Messages so using INFORMATION here
     compileContext.addMessage(CompilerMessageCategory.INFORMATION, "WARN: " + message, null, -1, -1);
+  }
+
+  void setSearchScopeFromFile(final File file) {
+    GlobalSearchScope searchScope = null;
+    if (file != null) {
+      VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByIoFile(file);
+      if (virtualFile != null) {
+        searchScope = findModule(virtualFile);
+        if (searchScope == null) {
+          String className = virtualFile.getName().replaceAll("$.*", "");
+          searchScope = findModule(virtualFile.getParent().findChild(className + ".class"));
+        }
+      }
+      if (searchScope == null) {
+        warn("Couldn't find the Module for file " + file);
+      }
+    }
+    this.searchScope = ofNullable(searchScope).orElse(this.globalSearchScope);
+  }
+
+  private GlobalSearchScope findModule(final VirtualFile virtualFile) {
+    for (Module module : compileContext.getCompileScope().getAffectedModules()) {
+      Set<VirtualFile> mainRoot = singleton(compileContext.getModuleOutputDirectory(module));
+      if (VfsUtil.isUnder(virtualFile, mainRoot)) {
+        return module.getModuleWithDependenciesAndLibrariesScope(false);
+      }
+      Set<VirtualFile> testRoot = singleton(compileContext.getModuleOutputDirectoryForTests(module));
+      if (VfsUtil.isUnder(virtualFile, testRoot)) {
+        return module.getModuleWithDependenciesAndLibrariesScope(true);
+      }
+    }
+    return null;
+  }
+
+  @NotNull
+  private String convertToClassNamePath(final String className) {
+    return className.replace('/', '.').replace('$', '.');
   }
 }

--- a/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassBytesReader.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassLoader.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassLoader.java
@@ -1,6 +1,10 @@
 package io.ebean.idea.ebean10.plugin;
 
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -31,10 +35,25 @@ public final class IdeaClassLoader extends ClassLoader {
 
   @Override
   protected Class<?> findClass(final String name) throws ClassNotFoundException {
-    try {
-      return super.findClass(name);
-    } catch (ClassNotFoundException e) {
-      return classCache.computeIfAbsent(name, this::readClass);
+    final Class<?> aClass = classCache.computeIfAbsent(name, this::readClass);
+    if (aClass == null) {
+      throw new ClassNotFoundException();
+    }
+    return aClass;
+  }
+
+  @Override
+  protected Enumeration<URL> findResources(final String name) throws IOException {
+    return Collections.enumeration(Collections.singleton(findResource(name)));
+  }
+
+  @Override
+  protected URL findResource(final String name) {
+    final byte[] bytes = bytesReader.getClassBytes(name.replaceAll("\\.class$", ""), parent);
+    if (bytes != null) {
+      return IOUtils.byteArrayToURL(bytes);
+    } else {
+      return null;
     }
   }
 

--- a/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassLoader.java
+++ b/src/main/java/io/ebean/idea/ebean10/plugin/IdeaClassLoader.java
@@ -1,9 +1,6 @@
 package io.ebean.idea.ebean10.plugin;
 
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.Enumeration;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -39,11 +36,6 @@ public final class IdeaClassLoader extends ClassLoader {
     } catch (ClassNotFoundException e) {
       return classCache.computeIfAbsent(name, this::readClass);
     }
-  }
-
-  @Override
-  public Enumeration<URL> getResources(String name) throws IOException {
-    return super.getResources(name);
   }
 
   private Class<?> readClass(String className) {


### PR DESCRIPTION
This fixes a couple of problems for us, as we use multiple modules with different class paths and have problems with ASM trying to find class hierarchy of other objects.

The main parts of the PR are 3 changes:
1. Search for classes in the class path of the module of the file being enhanced.
2. Remove/Don't use the class path for windows fix on unix.
3. Implement findResource in the IdeaClassLoader to let ASM load classes from the IdeaClassLoader(and in turn IdeaClassBytesReader)

With all these patches applied our application builds in IntelliJ, without them, it does not.

Our application was initially built with Ebean 2.7 and where we used the database objects as domain objects. This means we have a lot of switch(), returning new objects and even some dependencies on 3rd party libraries in the enhanced objects.
