### PR TITLE
Not defining properties should not fail the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,8 @@ compileJava   {
 }
 
 publishPlugin {
-    username project.property("intellij.username") ?: "none"
-    password project.property("intellij.password") ?: "none"
+    username project.hasProperty("intellij.username") ? project.property("intellij.username") : "none"
+    password project.hasProperty("intellij.password") ? project.property("intellij.password") : "none"
     channels 'nightly'
 }
 


### PR DESCRIPTION
Will default to "none" on undefined, as was intended.

As previously stated, my forte is not Gradle (nor testing apparently). This fix gives the intended effect of defaulting to "none" on undefined properties which should make it easier to build the project.